### PR TITLE
chore: tsc `target`을 ES2022로 변경

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
tsc target을 ES2017에서 ES2022로 변경
- ES2018: rest/spread operator
- ES2020: nullish coalescing, optional chaining
- ES2021: numeric separator, replaceAll
- ES2022: error cause