### PR TITLE
feat: 가독성과 터치 영역 확보를 위한 개인 정보 섹션 폰트 크기 키움

### DIFF
--- a/src/app/(home)/components/Introduction.tsx
+++ b/src/app/(home)/components/Introduction.tsx
@@ -58,7 +58,7 @@ const InfoLinkList = ({
   address,
 }: Pick<Introduction, 'github' | 'email' | 'phone' | 'address'>) => {
   return (
-    <p className="mt-3 flex max-w-sm flex-wrap justify-center gap-x-2 text-center text-sm">
+    <p className="mt-3 flex max-w-lg flex-wrap justify-center gap-x-2 text-center">
       <InfoLink label={github.split('https://')[1]} href={github} />
       <InfoLink
         label={email}
@@ -75,9 +75,13 @@ const InfoLinkList = ({
 
 const InfoLink = ({ label, href }: { label: string; href: string }) => {
   return (
-    <a target="_blank" rel="noopener noreferrer" href={href}>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href={href}
+      className="after:content-['_|_'] last:after:content-none"
+    >
       <span className="text-[#0000ee] underline">{label}</span>
-      <span> | </span>
     </a>
   );
 };


### PR DESCRIPTION
## 스크린샷

전
<img width="1280" height="815" alt="image" src="https://github.com/user-attachments/assets/dc7ee4c8-4556-446e-a68e-64cd6d77249f" />

후
<img width="1280" height="815" alt="image" src="https://github.com/user-attachments/assets/3e482aa0-bd37-4fba-b2bd-f124d9d4b077" />
